### PR TITLE
Mock getComputedTextLength function in jest

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,4 @@
+// This fixes a problem with the wrapTextWithEllipses function in britecharts
+// using getComputedTextLength and not being available because of jsdom.
+// More info in https://github.com/eventbrite/britecharts-react/pull/65#issuecomment-348726423
+window.Element.prototype.getComputedTextLength = () => 200;

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     ],
     "testPathIgnorePatterns": [
       "<rootDir>/node_modules/"
-    ]
+    ],
+    "setupTestFrameworkScriptFile": "<rootDir>/jest.setup.js"
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This is a continuation from https://github.com/eventbrite/britecharts-react/pull/65#issuecomment-348812251

## How Has This Been Tested?
Manually in a clone of Golodhros/britecharts-react

## Screenshots (if appropriate):
![screen shot 2017-12-03 at 21 55 56](https://user-images.githubusercontent.com/905225/33529701-d0c6db10-d874-11e7-9733-a3f8b927b06a.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
